### PR TITLE
Add build configuration for Java 1.6

### DIFF
--- a/inference-rxnorm/pom.xml
+++ b/inference-rxnorm/pom.xml
@@ -59,4 +59,15 @@
 	<developerConnection>scm:svn:https://svn.chpc.utah.edu/repo/openinfobutton/trunk/party3/infobutton/inference-rxnorm</developerConnection>
 	<url>https://svn.chpc.utah.edu/repo/openinfobutton/trunk/party3/infobutton/inference-rxnorm</url>
   </scm>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.6</source>
+					<target>1.6</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/infobutton-db/pom.xml
+++ b/infobutton-db/pom.xml
@@ -63,4 +63,15 @@
 		<url>https://svn.chpc.utah.edu/repo/openinfobutton/trunk/party3/infobutton/infobutton-db</url>
 	</scm>
 	
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.6</source>
+					<target>1.6</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/infobutton-externalresources/pom.xml
+++ b/infobutton-externalresources/pom.xml
@@ -248,4 +248,15 @@
 		<url>https://svn.chpc.utah.edu/repo/openinfobutton/trunk/party3/infobutton/infobutton-ExternalResources</url>
 	</scm>
     
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.6</source>
+					<target>1.6</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/infobutton-schema/pom.xml
+++ b/infobutton-schema/pom.xml
@@ -23,9 +23,9 @@ $Date:: 2011-01-13 1#$:  Date of last commit
   				</execution>
   			</executions>
 			<configuration>
-				<schemaDirectory>src\main\resources\</schemaDirectory>
+				<schemaDirectory>src/main/resources/</schemaDirectory>
 				<schemaFiles>KnowledgeResponse.xsd,binding.xjb,REDS_MT010001UV-Restricted-flattened-08-19-2011.xsd</schemaFiles>				
-				<outputDirectory>src\main\java</outputDirectory>
+				<outputDirectory>src/main/java</outputDirectory>
 				<packageName>org.hl7.v3</packageName>
 				<clearOutputDir>false</clearOutputDir>
 			</configuration>  			


### PR DESCRIPTION
Since java annotations are used we need to instruct maven to target Java
1.6 (Java 6) when compiling/building the application.

Also fix incorrect slashes \ vs / as / should be platform independant.
