### PR TITLE
POM changes to facilitate managing/releasing artifacts

### DIFF
--- a/oib-request/oib-ext-resources/pom.xml
+++ b/oib-request/oib-ext-resources/pom.xml
@@ -54,14 +54,10 @@
 	    <dependency>
 	  	  <groupId>org.openinfobutton</groupId>
 	  	  <artifactId>oib-request-schema</artifactId>
-	  	  <version>${openinfobutton.version}</version>
-	  	  <scope>compile</scope>
 	    </dependency>
 	    <dependency>
 	  	  <groupId>org.openinfobutton</groupId>
 	  	  <artifactId>oib-profile-schema</artifactId>
-	  	  <version>${openinfobutton.version}</version>
-	  	  <scope>compile</scope>
 	    </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -128,8 +124,6 @@
        <dependency>
        	<groupId>org.openinfobutton</groupId>
        	<artifactId>oib-request-db</artifactId>
-       	<version>${openinfobutton.version}</version>
-       	<scope>compile</scope>
        </dependency>
        <dependency>
        	<groupId>org.apache.commons</groupId>
@@ -196,14 +190,10 @@
        <dependency>
        	<groupId>edu.utah.openinfobutton</groupId>
        	<artifactId>oib-request-inference-rxnorm</artifactId>
-       	<version>${openinfobutton.version}</version>
        </dependency>
        <dependency>
        	<groupId>UTSMetathesaurus</groupId>
        	<artifactId>uts-metathesaurus</artifactId>
-       	<version>${openinfobutton.version}</version>
-       	<type>jar</type>
-       	<scope>compile</scope>
        </dependency>
   </dependencies>
     

--- a/oib-request/oib-ext-resources/pom.xml
+++ b/oib-request/oib-ext-resources/pom.xml
@@ -202,9 +202,9 @@
   </dependencies>
     
     <scm>
-		<connection>scm:svn:https://svn.chpc.utah.edu/repo/openinfobutton/trunk/party3/infobutton/infobutton-ExternalResources</connection>
-		<developerConnection>scm:svn:https://svn.chpc.utah.edu/repo/openinfobutton/trunk/party3/infobutton/infobutton-ExternalResources</developerConnection>
-		<url>https://svn.chpc.utah.edu/repo/openinfobutton/trunk/party3/infobutton/infobutton-ExternalResources</url>
+		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
+		<developerConnection>scm:svn:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
+		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
 	</scm>
     
 	<build>

--- a/oib-request/oib-ext-resources/pom.xml
+++ b/oib-request/oib-ext-resources/pom.xml
@@ -3,11 +3,12 @@
  <modelVersion>4.0.0</modelVersion>
   <groupId>edu.utah.openinfobutton</groupId>
   <artifactId>oib-ext-resources</artifactId>
-  <version>1.4</version>
+  <version>1.4-SNAPSHOT</version>
   <name>oib-ext-resources</name>
   <description>Decoupling the handling of external resources from Business Logic</description>
   <properties>
        <dts-version>3.5.0</dts-version>
+       <openinfobutton.version>1.4-SNAPSHOT</openinfobutton.version>
    </properties>
   
   <repositories>
@@ -47,13 +48,13 @@
 	    <dependency>
 	  	  <groupId>org.openinfobutton</groupId>
 	  	  <artifactId>oib-request-schema</artifactId>
-	  	  <version>1.4</version>
+	  	  <version>${openinfobutton.version}</version>
 	  	  <scope>compile</scope>
 	    </dependency>
 	    <dependency>
 	  	  <groupId>org.openinfobutton</groupId>
 	  	  <artifactId>oib-profile-schema</artifactId>
-	  	  <version>1.4</version>
+	  	  <version>${openinfobutton.version}</version>
 	  	  <scope>compile</scope>
 	    </dependency>
         <dependency>
@@ -121,7 +122,7 @@
        <dependency>
        	<groupId>org.openinfobutton</groupId>
        	<artifactId>oib-request-db</artifactId>
-       	<version>1.4</version>
+       	<version>${openinfobutton.version}</version>
        	<scope>compile</scope>
        </dependency>
        <dependency>
@@ -189,12 +190,12 @@
        <dependency>
        	<groupId>edu.utah.openinfobutton</groupId>
        	<artifactId>oib-request-inference-rxnorm</artifactId>
-       	<version>1.4</version>
+       	<version>${openinfobutton.version}</version>
        </dependency>
        <dependency>
        	<groupId>UTSMetathesaurus</groupId>
        	<artifactId>uts-metathesaurus</artifactId>
-       	<version>1.4</version>
+       	<version>${openinfobutton.version}</version>
        	<type>jar</type>
        	<scope>compile</scope>
        </dependency>

--- a/oib-request/oib-ext-resources/pom.xml
+++ b/oib-request/oib-ext-resources/pom.xml
@@ -1,11 +1,10 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
  <modelVersion>4.0.0</modelVersion>
  
    <parent>
 	<groupId>org.openinfobutton</groupId>
 	<artifactId>oib-request</artifactId>
-	<version>1.4-SNAPSHOT</version>
+	<version>1.4-M1</version>
   </parent>
  
   <groupId>edu.utah.openinfobutton</groupId>

--- a/oib-request/oib-ext-resources/pom.xml
+++ b/oib-request/oib-ext-resources/pom.xml
@@ -201,11 +201,11 @@
        </dependency>
   </dependencies>
     
-    <scm>
+<!--     <scm>
 		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
 		<developerConnection>scm:svn:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
 		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
-	</scm>
+	</scm> -->
     
 	<build>
 		<plugins>

--- a/oib-request/oib-ext-resources/pom.xml
+++ b/oib-request/oib-ext-resources/pom.xml
@@ -1,9 +1,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
  <modelVersion>4.0.0</modelVersion>
+ 
+   <parent>
+	<groupId>org.openinfobutton</groupId>
+	<artifactId>oib-request</artifactId>
+	<version>1.4-SNAPSHOT</version>
+  </parent>
+ 
   <groupId>edu.utah.openinfobutton</groupId>
   <artifactId>oib-ext-resources</artifactId>
-  <version>1.4-SNAPSHOT</version>
+
   <name>oib-ext-resources</name>
   <description>Decoupling the handling of external resources from Business Logic</description>
   <properties>

--- a/oib-request/oib-ext-resources/pom.xml
+++ b/oib-request/oib-ext-resources/pom.xml
@@ -15,7 +15,6 @@
   <description>Decoupling the handling of external resources from Business Logic</description>
   <properties>
        <dts-version>3.5.0</dts-version>
-       <openinfobutton.version>1.4-SNAPSHOT</openinfobutton.version>
    </properties>
   
   <repositories>

--- a/oib-request/oib-ext-resources/pom.xml
+++ b/oib-request/oib-ext-resources/pom.xml
@@ -207,12 +207,6 @@
        </dependency>
   </dependencies>
     
-	<scm>
-		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
-		<developerConnection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
-		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
-	</scm>
-    
 	<build>
 		<plugins>
 			<plugin>

--- a/oib-request/oib-ext-resources/pom.xml
+++ b/oib-request/oib-ext-resources/pom.xml
@@ -203,7 +203,7 @@
     
 <!--     <scm>
 		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
-		<developerConnection>scm:svn:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
+		<developerConnection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
 		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
 	</scm> -->
     

--- a/oib-request/oib-ext-resources/pom.xml
+++ b/oib-request/oib-ext-resources/pom.xml
@@ -201,11 +201,11 @@
        </dependency>
   </dependencies>
     
-<!--     <scm>
+	<scm>
 		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
 		<developerConnection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
 		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
-	</scm> -->
+	</scm>
     
 	<build>
 		<plugins>

--- a/oib-request/oib-ext-resources/pom.xml
+++ b/oib-request/oib-ext-resources/pom.xml
@@ -4,7 +4,7 @@
    <parent>
 	<groupId>org.openinfobutton</groupId>
 	<artifactId>oib-request</artifactId>
-	<version>1.4-M1</version>
+	<version>1.4-SNAPSHOT</version>
   </parent>
  
   <groupId>edu.utah.openinfobutton</groupId>

--- a/oib-request/oib-profile-schema/pom.xml
+++ b/oib-request/oib-profile-schema/pom.xml
@@ -43,10 +43,10 @@ $Date:: 2011-01-28 1#$:  Date of last commit
   	</plugins>
   </build>
   
- 	<scm>
-		<connection>scm:svn:https://svn.chpc.utah.edu/repo/openinfobutton/trunk/party3/infobutton/infobutton-kbschema</connection>
-		<developerConnection>scm:svn:https://svn.chpc.utah.edu/repo/openinfobutton/trunk/party3/infobutton/infobutton-kbschema</developerConnection>
-		<url>https://svn.chpc.utah.edu/repo/openinfobutton/trunk/party3/infobutton/infobutton-kbschema</url>
+    <scm>
+		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
+		<developerConnection>scm:svn:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
+		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
 	</scm>
 	
 </project>

--- a/oib-request/oib-profile-schema/pom.xml
+++ b/oib-request/oib-profile-schema/pom.xml
@@ -45,7 +45,7 @@ $Date:: 2011-01-28 1#$:  Date of last commit
   
     <scm>
 		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
-		<developerConnection>scm:svn:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
+		<developerConnection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
 		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
 	</scm>
 	

--- a/oib-request/oib-profile-schema/pom.xml
+++ b/oib-request/oib-profile-schema/pom.xml
@@ -9,7 +9,7 @@ $Date:: 2011-01-28 1#$:  Date of last commit
    <parent>
 	<groupId>org.openinfobutton</groupId>
 	<artifactId>oib-request</artifactId>
-	<version>1.4-M1</version>
+	<version>1.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>oib-profile-schema</artifactId>

--- a/oib-request/oib-profile-schema/pom.xml
+++ b/oib-request/oib-profile-schema/pom.xml
@@ -47,10 +47,5 @@ $Date:: 2011-01-28 1#$:  Date of last commit
   	</plugins>
   </build>
   
-    <scm>
-		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
-		<developerConnection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
-		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
-	</scm>
 	
 </project>

--- a/oib-request/oib-profile-schema/pom.xml
+++ b/oib-request/oib-profile-schema/pom.xml
@@ -6,9 +6,13 @@ $Date:: 2011-01-28 1#$:  Date of last commit
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
- <groupId>org.openinfobutton</groupId>
+   <parent>
+	<groupId>org.openinfobutton</groupId>
+	<artifactId>oib-request</artifactId>
+	<version>1.4-SNAPSHOT</version>
+  </parent>
+
   <artifactId>oib-profile-schema</artifactId>
-  <version>1.4-SNAPSHOT</version>
   <name>oib-profile-schema</name>
   <description>Knowledge base schema</description>
   <build>

--- a/oib-request/oib-profile-schema/pom.xml
+++ b/oib-request/oib-profile-schema/pom.xml
@@ -8,7 +8,7 @@ $Date:: 2011-01-28 1#$:  Date of last commit
   <modelVersion>4.0.0</modelVersion>
  <groupId>org.openinfobutton</groupId>
   <artifactId>oib-profile-schema</artifactId>
-  <version>1.4</version>
+  <version>1.4-SNAPSHOT</version>
   <name>oib-profile-schema</name>
   <description>Knowledge base schema</description>
   <build>

--- a/oib-request/oib-profile-schema/pom.xml
+++ b/oib-request/oib-profile-schema/pom.xml
@@ -9,7 +9,7 @@ $Date:: 2011-01-28 1#$:  Date of last commit
    <parent>
 	<groupId>org.openinfobutton</groupId>
 	<artifactId>oib-request</artifactId>
-	<version>1.4-SNAPSHOT</version>
+	<version>1.4-M1</version>
   </parent>
 
   <artifactId>oib-profile-schema</artifactId>

--- a/oib-request/oib-request-db/pom.xml
+++ b/oib-request/oib-request-db/pom.xml
@@ -1,9 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-<modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openinfobutton</groupId>
 	<artifactId>oib-request-db</artifactId>
-<version>1.4</version>
+	<version>1.4-SNAPSHOT</version>
 	
    <repositories>
   		<repository>
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>edu.utah.further.core</groupId>
 			<artifactId>core-data</artifactId>
-			<version>1.4.0-SNAPSHOT</version>
+			<version>1.4.0</version>
 		    <exclusions>
 		    	<exclusion>
 		    		<artifactId>spring-jdbc</artifactId>
@@ -69,7 +69,7 @@
 		<dependency>
 			<groupId>edu.utah.further.core</groupId>
 			<artifactId>core-test</artifactId>
-			<version>1.4.0-SNAPSHOT</version>
+			<version>1.4.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/oib-request/oib-request-db/pom.xml
+++ b/oib-request/oib-request-db/pom.xml
@@ -83,7 +83,7 @@
 	
     <scm>
 		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
-		<developerConnection>scm:svn:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
+		<developerConnection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
 		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
 	</scm>
 	

--- a/oib-request/oib-request-db/pom.xml
+++ b/oib-request/oib-request-db/pom.xml
@@ -81,10 +81,10 @@
 		</dependency>
 	</dependencies>
 	
- 	<scm>
-		<connection>scm:svn:https://svn.chpc.utah.edu/repo/openinfobutton/trunk/party3/infobutton/infobutton-db</connection>
-		<developerConnection>scm:svn:https://svn.chpc.utah.edu/repo/openinfobutton/trunk/party3/infobutton/infobutton-db</developerConnection>
-		<url>https://svn.chpc.utah.edu/repo/openinfobutton/trunk/party3/infobutton/infobutton-db</url>
+    <scm>
+		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
+		<developerConnection>scm:svn:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
+		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
 	</scm>
 	
 	<build>

--- a/oib-request/oib-request-db/pom.xml
+++ b/oib-request/oib-request-db/pom.xml
@@ -86,11 +86,6 @@
 		</dependency>
 	</dependencies>
 	
-    <scm>
-		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
-		<developerConnection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
-		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
-	</scm>
 	
 	<build>
 		<plugins>

--- a/oib-request/oib-request-db/pom.xml
+++ b/oib-request/oib-request-db/pom.xml
@@ -1,9 +1,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+	
+   <parent>
 	<groupId>org.openinfobutton</groupId>
-	<artifactId>oib-request-db</artifactId>
+	<artifactId>oib-request</artifactId>
 	<version>1.4-SNAPSHOT</version>
+  </parent>
+
+	<artifactId>oib-request-db</artifactId>
 	
    <repositories>
   		<repository>

--- a/oib-request/oib-request-db/pom.xml
+++ b/oib-request/oib-request-db/pom.xml
@@ -1,11 +1,10 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	
    <parent>
 	<groupId>org.openinfobutton</groupId>
 	<artifactId>oib-request</artifactId>
-	<version>1.4-SNAPSHOT</version>
+	<version>1.4-M1</version>
   </parent>
 
 	<artifactId>oib-request-db</artifactId>

--- a/oib-request/oib-request-db/pom.xml
+++ b/oib-request/oib-request-db/pom.xml
@@ -4,7 +4,7 @@
    <parent>
 	<groupId>org.openinfobutton</groupId>
 	<artifactId>oib-request</artifactId>
-	<version>1.4-M1</version>
+	<version>1.4-SNAPSHOT</version>
   </parent>
 
 	<artifactId>oib-request-db</artifactId>

--- a/oib-request/oib-request-inference-rxnorm/pom.xml
+++ b/oib-request/oib-request-inference-rxnorm/pom.xml
@@ -61,11 +61,6 @@
   		<version>${openinfobutton.version}</version>
   	</dependency>
   </dependencies>
-    <scm>
-		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
-		<developerConnection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
-		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
-	</scm>
 	<build>
 		<plugins>
 			<plugin>

--- a/oib-request/oib-request-inference-rxnorm/pom.xml
+++ b/oib-request/oib-request-inference-rxnorm/pom.xml
@@ -4,7 +4,7 @@
    <parent>
 	<groupId>org.openinfobutton</groupId>
 	<artifactId>oib-request</artifactId>
-	<version>1.4-SNAPSHOT</version>
+	<version>1.4-M1</version>
   </parent>
  
   <groupId>edu.utah.openinfobutton</groupId>

--- a/oib-request/oib-request-inference-rxnorm/pom.xml
+++ b/oib-request/oib-request-inference-rxnorm/pom.xml
@@ -58,7 +58,6 @@
   	<dependency>
   		<groupId>org.openinfobutton</groupId>
   		<artifactId>oib-request-schema</artifactId>
-  		<version>${openinfobutton.version}</version>
   	</dependency>
   </dependencies>
 	<build>

--- a/oib-request/oib-request-inference-rxnorm/pom.xml
+++ b/oib-request/oib-request-inference-rxnorm/pom.xml
@@ -13,10 +13,6 @@
   <name>oib-request-inference-rxnorm</name>
   <description>RXNorm REST API Client</description>
     
-  <properties>
-  	<openinfobutton.version>1.4-SNAPSHOT</openinfobutton.version>
-  </properties>
-    
     <repositories>
  		<repository>
 		<id>further</id>

--- a/oib-request/oib-request-inference-rxnorm/pom.xml
+++ b/oib-request/oib-request-inference-rxnorm/pom.xml
@@ -58,11 +58,11 @@
   		<version>${openinfobutton.version}</version>
   	</dependency>
   </dependencies>
-  <scm>
-	<connection>scm:svn:https://svn.chpc.utah.edu/repo/openinfobutton/trunk/party3/infobutton/inference-rxnorm</connection>
-	<developerConnection>scm:svn:https://svn.chpc.utah.edu/repo/openinfobutton/trunk/party3/infobutton/inference-rxnorm</developerConnection>
-	<url>https://svn.chpc.utah.edu/repo/openinfobutton/trunk/party3/infobutton/inference-rxnorm</url>
-  </scm>
+    <scm>
+		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
+		<developerConnection>scm:svn:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
+		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
+	</scm>
 	<build>
 		<plugins>
 			<plugin>

--- a/oib-request/oib-request-inference-rxnorm/pom.xml
+++ b/oib-request/oib-request-inference-rxnorm/pom.xml
@@ -1,8 +1,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
  <modelVersion>4.0.0</modelVersion>
+ 
+   <parent>
+	<groupId>org.openinfobutton</groupId>
+	<artifactId>oib-request</artifactId>
+	<version>1.4-SNAPSHOT</version>
+  </parent>
+ 
   <groupId>edu.utah.openinfobutton</groupId>
   <artifactId>oib-request-inference-rxnorm</artifactId>
-  <version>1.4-SNAPSHOT</version>
+
   <name>oib-request-inference-rxnorm</name>
   <description>RXNorm REST API Client</description>
     

--- a/oib-request/oib-request-inference-rxnorm/pom.xml
+++ b/oib-request/oib-request-inference-rxnorm/pom.xml
@@ -2,9 +2,13 @@
  <modelVersion>4.0.0</modelVersion>
   <groupId>edu.utah.openinfobutton</groupId>
   <artifactId>oib-request-inference-rxnorm</artifactId>
-  <version>1.4</version>
+  <version>1.4-SNAPSHOT</version>
   <name>oib-request-inference-rxnorm</name>
   <description>RXNorm REST API Client</description>
+    
+  <properties>
+  	<openinfobutton.version>1.4-SNAPSHOT</openinfobutton.version>
+  </properties>
     
     <repositories>
  		<repository>
@@ -45,13 +49,13 @@
   	<dependency>
   		<groupId>edu.utah.further.core</groupId>
   		<artifactId>core-xml</artifactId>
-  		<version>1.4.0-SNAPSHOT</version>
+  		<version>1.4.0</version>
   		<type>jar</type>
   	</dependency>
   	<dependency>
   		<groupId>org.openinfobutton</groupId>
   		<artifactId>oib-request-schema</artifactId>
-  		<version>1.4</version>
+  		<version>${openinfobutton.version}</version>
   	</dependency>
   </dependencies>
   <scm>

--- a/oib-request/oib-request-inference-rxnorm/pom.xml
+++ b/oib-request/oib-request-inference-rxnorm/pom.xml
@@ -60,7 +60,7 @@
   </dependencies>
     <scm>
 		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
-		<developerConnection>scm:svn:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
+		<developerConnection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
 		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
 	</scm>
 	<build>

--- a/oib-request/oib-request-inference-rxnorm/pom.xml
+++ b/oib-request/oib-request-inference-rxnorm/pom.xml
@@ -4,7 +4,7 @@
    <parent>
 	<groupId>org.openinfobutton</groupId>
 	<artifactId>oib-request</artifactId>
-	<version>1.4-M1</version>
+	<version>1.4-SNAPSHOT</version>
   </parent>
  
   <groupId>edu.utah.openinfobutton</groupId>

--- a/oib-request/oib-request-schema/pom.xml
+++ b/oib-request/oib-request-schema/pom.xml
@@ -54,10 +54,10 @@ $Date:: 2011-01-13 1#$:  Date of last commit
 	    </dependency>
   </dependencies>
   
-  <scm>
-	<connection>scm:svn:https://svn.chpc.utah.edu/repo/openinfobutton/trunk/party3/infobutton/infobutton-schema</connection>
-	<developerConnection>scm:svn:https://svn.chpc.utah.edu/repo/openinfobutton/trunk/party3/infobutton/infobutton-schema</developerConnection>
-	<url>https://svn.chpc.utah.edu/repo/openinfobutton/trunk/party3/infobutton/infobutton-schema</url>
-  </scm>
+    <scm>
+		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
+		<developerConnection>scm:svn:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
+		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
+	</scm>
     <name>oib-request-schema</name>
 </project>

--- a/oib-request/oib-request-schema/pom.xml
+++ b/oib-request/oib-request-schema/pom.xml
@@ -6,9 +6,14 @@ $Date:: 2011-01-13 1#$:  Date of last commit
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
  <modelVersion>4.0.0</modelVersion>
-  <groupId>org.openinfobutton</groupId>
+ 
+   <parent>
+	<groupId>org.openinfobutton</groupId>
+	<artifactId>oib-request</artifactId>
+	<version>1.4-SNAPSHOT</version>
+  </parent>
+
   <artifactId>oib-request-schema</artifactId>
-  <version>1.4-SNAPSHOT</version>
   
   <properties>
   	<openinfobutton.version>1.4-SNAPSHOT</openinfobutton.version>

--- a/oib-request/oib-request-schema/pom.xml
+++ b/oib-request/oib-request-schema/pom.xml
@@ -10,7 +10,7 @@ $Date:: 2011-01-13 1#$:  Date of last commit
    <parent>
 	<groupId>org.openinfobutton</groupId>
 	<artifactId>oib-request</artifactId>
-	<version>1.4-SNAPSHOT</version>
+	<version>1.4-M1</version>
   </parent>
 
   <artifactId>oib-request-schema</artifactId>

--- a/oib-request/oib-request-schema/pom.xml
+++ b/oib-request/oib-request-schema/pom.xml
@@ -8,7 +8,11 @@ $Date:: 2011-01-13 1#$:  Date of last commit
  <modelVersion>4.0.0</modelVersion>
   <groupId>org.openinfobutton</groupId>
   <artifactId>oib-request-schema</artifactId>
-  <version>1.4</version>
+  <version>1.4-SNAPSHOT</version>
+  
+  <properties>
+  	<openinfobutton.version>1.4-SNAPSHOT</openinfobutton.version>
+  </properties>
   <build>
   	<plugins>
   		<plugin>
@@ -45,7 +49,7 @@ $Date:: 2011-01-13 1#$:  Date of last commit
       <dependency>
 	  	  <groupId>org.openinfobutton</groupId>
 	  	  <artifactId>oib-profile-schema</artifactId>
-	  	  <version>1.4</version>
+	  	  <version>${openinfobutton.version}</version>
 	  	  <scope>compile</scope>
 	    </dependency>
   </dependencies>

--- a/oib-request/oib-request-schema/pom.xml
+++ b/oib-request/oib-request-schema/pom.xml
@@ -15,9 +15,6 @@ $Date:: 2011-01-13 1#$:  Date of last commit
 
   <artifactId>oib-request-schema</artifactId>
   
-  <properties>
-  	<openinfobutton.version>1.4-SNAPSHOT</openinfobutton.version>
-  </properties>
   <build>
   	<plugins>
   		<plugin>

--- a/oib-request/oib-request-schema/pom.xml
+++ b/oib-request/oib-request-schema/pom.xml
@@ -56,7 +56,7 @@ $Date:: 2011-01-13 1#$:  Date of last commit
   
     <scm>
 		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
-		<developerConnection>scm:svn:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
+		<developerConnection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
 		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
 	</scm>
     <name>oib-request-schema</name>

--- a/oib-request/oib-request-schema/pom.xml
+++ b/oib-request/oib-request-schema/pom.xml
@@ -51,8 +51,6 @@ $Date:: 2011-01-13 1#$:  Date of last commit
       <dependency>
 	  	  <groupId>org.openinfobutton</groupId>
 	  	  <artifactId>oib-profile-schema</artifactId>
-	  	  <version>${openinfobutton.version}</version>
-	  	  <scope>compile</scope>
 	    </dependency>
   </dependencies>
   

--- a/oib-request/oib-request-schema/pom.xml
+++ b/oib-request/oib-request-schema/pom.xml
@@ -56,10 +56,5 @@ $Date:: 2011-01-13 1#$:  Date of last commit
 	    </dependency>
   </dependencies>
   
-    <scm>
-		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
-		<developerConnection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
-		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
-	</scm>
     <name>oib-request-schema</name>
 </project>

--- a/oib-request/oib-request-schema/pom.xml
+++ b/oib-request/oib-request-schema/pom.xml
@@ -10,7 +10,7 @@ $Date:: 2011-01-13 1#$:  Date of last commit
    <parent>
 	<groupId>org.openinfobutton</groupId>
 	<artifactId>oib-request</artifactId>
-	<version>1.4-M1</version>
+	<version>1.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>oib-request-schema</artifactId>

--- a/oib-request/oib-request-service/pom.xml
+++ b/oib-request/oib-request-service/pom.xml
@@ -9,7 +9,7 @@ $Date:: 2011-02-24 1#$:  Date of last commit
    <parent>
 	<groupId>org.openinfobutton</groupId>
 	<artifactId>oib-request</artifactId>
-	<version>1.4-M1</version>
+	<version>1.4-SNAPSHOT</version>
   </parent>
 
     <artifactId>oib-request-service</artifactId>

--- a/oib-request/oib-request-service/pom.xml
+++ b/oib-request/oib-request-service/pom.xml
@@ -7,15 +7,23 @@ $Date:: 2011-02-24 1#$:  Date of last commit
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <modelVersion>4.0.0</modelVersion>
+   <parent>
+	<groupId>org.openinfobutton</groupId>
+	<artifactId>oib-request</artifactId>
+	<version>1.4-SNAPSHOT</version>
+  </parent>
     <groupId>org.openinfobutton</groupId>
     <artifactId>oib-request-service</artifactId>
     <packaging>war</packaging>
-    <version>1.4</version>
+    <version>1.4-SNAPSHOT</version>
     <name>oib-request-service</name>
     <url>http://maven.apache.org</url>
    <properties>
        <dts-version>3.5.0</dts-version>
-              
+        
+        <openinfobutton.version>1.4-SNAPSHOT</openinfobutton.version>
+        <org.jacoco.version>0.7.1.201405082137</org.jacoco.version>
+        
 		<datasource1.url>jdbc:mysql://localhost:3306/prodoib</datasource1.url>
 		<datasource1.driver>com.mysql.jdbc.Driver</datasource1.driver>
 		<datasource1.user>root</datasource1.user>
@@ -66,13 +74,13 @@ $Date:: 2011-02-24 1#$:  Date of last commit
 	    <dependency>
 	  	  <groupId>org.openinfobutton</groupId>
 	  	  <artifactId>oib-request-schema</artifactId>
-	  	  <version>1.4</version>
+	  	  <version>${openinfobutton.version}</version>
 	  	  <scope>compile</scope>
 	    </dependency>
 	    <dependency>
 	  	  <groupId>org.openinfobutton</groupId>
 	  	  <artifactId>oib-profile-schema</artifactId>
-	  	  <version>1.4</version>
+	  	  <version>${openinfobutton.version}</version>
 	  	  <scope>compile</scope>
 	    </dependency>
 	    
@@ -129,7 +137,7 @@ $Date:: 2011-02-24 1#$:  Date of last commit
        <dependency>
        	<groupId>org.openinfobutton</groupId>
        	<artifactId>oib-request-db</artifactId>
-       	<version>1.4</version>
+       	<version>${openinfobutton.version}</version>
        	<scope>compile</scope>
        </dependency>
        <dependency>
@@ -197,12 +205,12 @@ $Date:: 2011-02-24 1#$:  Date of last commit
        <dependency>
        	<groupId>edu.utah.openinfobutton</groupId>
        	<artifactId>oib-request-inference-rxnorm</artifactId>
-       	<version>1.4</version>
+       	<version>${openinfobutton.version}</version>
        </dependency>
        <dependency>
        	<groupId>edu.utah.openinfobutton</groupId>
        	<artifactId>oib-ext-resources</artifactId>
-       	<version>1.4</version>
+       	<version>${openinfobutton.version}</version>
        </dependency>
        <dependency>
       	<groupId>com.google.code.gson</groupId>
@@ -266,6 +274,36 @@ $Date:: 2011-02-24 1#$:  Date of last commit
 			</excludes>
 		  </testResource>
 		</testResources>
+        <pluginManagement>
+               <plugins>
+                     <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                           <lifecycleMappingMetadata>
+                                  <pluginExecutions>
+                                         <pluginExecution>
+                                                <pluginExecutionFilter>
+								  <groupId>org.jacoco</groupId>
+								  <artifactId>jacoco-maven-plugin</artifactId>
+								  <versionRange>${org.jacoco.version}</versionRange>
+                                                    <goals>
+                                                          <goal>prepare-agent</goal>
+                                                    </goals>
+                                                </pluginExecutionFilter>
+                                                <action>
+                                                       <execute>
+                                                              <runOnIncremental>true</runOnIncremental>
+                                                       </execute>
+                                                </action>
+                                         </pluginExecution>
+                                  </pluginExecutions>
+                           </lifecycleMappingMetadata>
+                    </configuration>
+             </plugin>
+               </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -316,7 +354,7 @@ $Date:: 2011-02-24 1#$:  Date of last commit
 			<plugin>
 			  <groupId>org.jacoco</groupId>
 			  <artifactId>jacoco-maven-plugin</artifactId>
-			  <version>0.7.1.201405082137</version>
+			  <version>${org.jacoco.version}</version>
 	          <configuration>
 	           <destfile>${basedir}/target/coverage-reports/jacoco-unit.exec</destfile>
 	          </configuration>			

--- a/oib-request/oib-request-service/pom.xml
+++ b/oib-request/oib-request-service/pom.xml
@@ -12,10 +12,10 @@ $Date:: 2011-02-24 1#$:  Date of last commit
 	<artifactId>oib-request</artifactId>
 	<version>1.4-SNAPSHOT</version>
   </parent>
-    <groupId>org.openinfobutton</groupId>
+
     <artifactId>oib-request-service</artifactId>
     <packaging>war</packaging>
-    <version>1.4-SNAPSHOT</version>
+
     <name>oib-request-service</name>
     <url>http://maven.apache.org</url>
    <properties>

--- a/oib-request/oib-request-service/pom.xml
+++ b/oib-request/oib-request-service/pom.xml
@@ -4,13 +4,12 @@ $Author:: ai28       $:  Author of last commit
 $Date:: 2011-02-24 1#$:  Date of last commit
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <parent>
 	<groupId>org.openinfobutton</groupId>
 	<artifactId>oib-request</artifactId>
-	<version>1.4-SNAPSHOT</version>
+	<version>1.4-M1</version>
   </parent>
 
     <artifactId>oib-request-service</artifactId>
@@ -33,8 +32,8 @@ $Date:: 2011-02-24 1#$:  Date of last commit
 		<datasource2.user>root</datasource2.user>
 		<datasource2.password>password</datasource2.password>
 		
-		<umls.username></umls.username>
-		<umls.password></umls.password>
+		<umls.username />
+		<umls.password />
    </properties>
  
    <repositories>

--- a/oib-request/oib-request-service/pom.xml
+++ b/oib-request/oib-request-service/pom.xml
@@ -21,7 +21,6 @@ $Date:: 2011-02-24 1#$:  Date of last commit
    <properties>
        <dts-version>3.5.0</dts-version>
         
-        <openinfobutton.version>1.4-SNAPSHOT</openinfobutton.version>
         <org.jacoco.version>0.7.1.201405082137</org.jacoco.version>
         
 		<datasource1.url>jdbc:mysql://localhost:3306/prodoib</datasource1.url>

--- a/oib-request/oib-request-service/pom.xml
+++ b/oib-request/oib-request-service/pom.xml
@@ -403,10 +403,10 @@ $Date:: 2011-02-24 1#$:  Date of last commit
         <finalName>infobutton-service</finalName>
     </build>
   
- 	<scm>
-		<connection>scm:svn:https://svn.chpc.utah.edu/repo/openinfobutton/trunk/party3/infobutton/infobutton-service</connection>
-		<developerConnection>scm:svn:https://svn.chpc.utah.edu/repo/openinfobutton/trunk/party3/infobutton/infobutton-service</developerConnection>
-		<url>https://svn.chpc.utah.edu/repo/openinfobutton/trunk/party3/infobutton/infobutton-service</url>
+    <scm>
+		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
+		<developerConnection>scm:svn:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
+		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
 	</scm>
  
 </project>

--- a/oib-request/oib-request-service/pom.xml
+++ b/oib-request/oib-request-service/pom.xml
@@ -402,11 +402,6 @@ $Date:: 2011-02-24 1#$:  Date of last commit
         <finalName>infobutton-service</finalName>
     </build>
   
-    <scm>
-		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
-		<developerConnection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
-		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
-	</scm>
  
 </project>
 

--- a/oib-request/oib-request-service/pom.xml
+++ b/oib-request/oib-request-service/pom.xml
@@ -405,7 +405,7 @@ $Date:: 2011-02-24 1#$:  Date of last commit
   
     <scm>
 		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
-		<developerConnection>scm:svn:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
+		<developerConnection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
 		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
 	</scm>
  

--- a/oib-request/oib-request-service/pom.xml
+++ b/oib-request/oib-request-service/pom.xml
@@ -73,14 +73,10 @@ $Date:: 2011-02-24 1#$:  Date of last commit
 	    <dependency>
 	  	  <groupId>org.openinfobutton</groupId>
 	  	  <artifactId>oib-request-schema</artifactId>
-	  	  <version>${openinfobutton.version}</version>
-	  	  <scope>compile</scope>
 	    </dependency>
 	    <dependency>
 	  	  <groupId>org.openinfobutton</groupId>
 	  	  <artifactId>oib-profile-schema</artifactId>
-	  	  <version>${openinfobutton.version}</version>
-	  	  <scope>compile</scope>
 	    </dependency>
 	    
        <dependency>
@@ -136,7 +132,6 @@ $Date:: 2011-02-24 1#$:  Date of last commit
        <dependency>
        	<groupId>org.openinfobutton</groupId>
        	<artifactId>oib-request-db</artifactId>
-       	<version>${openinfobutton.version}</version>
        	<scope>compile</scope>
        </dependency>
        <dependency>
@@ -204,12 +199,10 @@ $Date:: 2011-02-24 1#$:  Date of last commit
        <dependency>
        	<groupId>edu.utah.openinfobutton</groupId>
        	<artifactId>oib-request-inference-rxnorm</artifactId>
-       	<version>${openinfobutton.version}</version>
        </dependency>
        <dependency>
        	<groupId>edu.utah.openinfobutton</groupId>
        	<artifactId>oib-ext-resources</artifactId>
-       	<version>${openinfobutton.version}</version>
        </dependency>
        <dependency>
       	<groupId>com.google.code.gson</groupId>

--- a/oib-request/pom.xml
+++ b/oib-request/pom.xml
@@ -1,10 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
   	<groupId>org.openinfobutton</groupId>
 	<artifactId>oib-parent</artifactId>
-	<version>1.4-SNAPSHOT</version>
+	<version>1.4-M1</version>
   </parent>
   <artifactId>oib-request</artifactId>
   <packaging>pom</packaging>

--- a/oib-request/pom.xml
+++ b/oib-request/pom.xml
@@ -13,6 +13,15 @@
 		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
 	</scm>
   
+  <build>
+  	<pluginManagement>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>2.5</version>
+      </plugin>
+  	</pluginManagement>
+  </build>
   
     <modules>
         <module>oib-profile-schema</module>

--- a/oib-request/pom.xml
+++ b/oib-request/pom.xml
@@ -10,11 +10,6 @@
   <packaging>pom</packaging>
   <name>oib-request</name>
   
-    <scm>
-		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
-		<developerConnection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
-		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
-	</scm>
   
   <build>
   	<pluginManagement>

--- a/oib-request/pom.xml
+++ b/oib-request/pom.xml
@@ -3,7 +3,7 @@
   <parent>
   	<groupId>org.openinfobutton</groupId>
 	<artifactId>oib-parent</artifactId>
-	<version>1.4-M1</version>
+	<version>1.4-SNAPSHOT</version>
   </parent>
   <artifactId>oib-request</artifactId>
   <packaging>pom</packaging>

--- a/oib-request/pom.xml
+++ b/oib-request/pom.xml
@@ -10,19 +10,6 @@
   <packaging>pom</packaging>
   <name>oib-request</name>
   
-  
-  <build>
-  	<pluginManagement>
-	  	<plugins>
-	      <plugin>
-	        <groupId>org.apache.maven.plugins</groupId>
-	        <artifactId>maven-release-plugin</artifactId>
-	        <version>2.5</version>
-	      </plugin>
-	    </plugins>
-  	</pluginManagement>
-  </build>
-  
     <modules>
         <module>oib-profile-schema</module>
         <module>oib-request-schema</module>

--- a/oib-request/pom.xml
+++ b/oib-request/pom.xml
@@ -6,6 +6,14 @@
   <version>1.4-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>oib-request</name>
+  
+    <scm>
+		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
+		<developerConnection>scm:svn:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
+		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
+	</scm>
+  
+  
     <modules>
         <module>oib-profile-schema</module>
         <module>oib-request-schema</module>

--- a/oib-request/pom.xml
+++ b/oib-request/pom.xml
@@ -9,7 +9,7 @@
   
     <scm>
 		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
-		<developerConnection>scm:svn:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
+		<developerConnection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
 		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
 	</scm>
   

--- a/oib-request/pom.xml
+++ b/oib-request/pom.xml
@@ -15,11 +15,13 @@
   
   <build>
   	<pluginManagement>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.5</version>
-      </plugin>
+	  	<plugins>
+	      <plugin>
+	        <groupId>org.apache.maven.plugins</groupId>
+	        <artifactId>maven-release-plugin</artifactId>
+	        <version>2.5</version>
+	      </plugin>
+	    </plugins>
   	</pluginManagement>
   </build>
   

--- a/oib-request/uts-metathesaurus/pom.xml
+++ b/oib-request/uts-metathesaurus/pom.xml
@@ -4,7 +4,7 @@
    <parent>
 	<groupId>org.openinfobutton</groupId>
 	<artifactId>oib-request</artifactId>
-	<version>1.4-M1</version>
+	<version>1.4-SNAPSHOT</version>
   </parent>
  
   <groupId>UTSMetathesaurus</groupId>

--- a/oib-request/uts-metathesaurus/pom.xml
+++ b/oib-request/uts-metathesaurus/pom.xml
@@ -12,11 +12,6 @@
 
   <name>uts-metathesaurus</name>
   
-    <scm>
-		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
-		<developerConnection>scm:svn:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
-		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
-	</scm>
   
     <repositories>
   		<repository>

--- a/oib-request/uts-metathesaurus/pom.xml
+++ b/oib-request/uts-metathesaurus/pom.xml
@@ -4,6 +4,13 @@
   <artifactId>uts-metathesaurus</artifactId>
   <version>1.4</version>
   <name>uts-metathesaurus</name>
+  
+    <scm>
+		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
+		<developerConnection>scm:svn:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
+		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
+	</scm>
+  
     <repositories>
   		<repository>
 			<id>further</id>

--- a/oib-request/uts-metathesaurus/pom.xml
+++ b/oib-request/uts-metathesaurus/pom.xml
@@ -1,8 +1,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
  <modelVersion>4.0.0</modelVersion>
+ 
+   <parent>
+	<groupId>org.openinfobutton</groupId>
+	<artifactId>oib-request</artifactId>
+	<version>1.4-SNAPSHOT</version>
+  </parent>
+ 
   <groupId>UTSMetathesaurus</groupId>
   <artifactId>uts-metathesaurus</artifactId>
-  <version>1.4</version>
+
   <name>uts-metathesaurus</name>
   
     <scm>

--- a/oib-request/uts-metathesaurus/pom.xml
+++ b/oib-request/uts-metathesaurus/pom.xml
@@ -4,7 +4,7 @@
    <parent>
 	<groupId>org.openinfobutton</groupId>
 	<artifactId>oib-request</artifactId>
-	<version>1.4-SNAPSHOT</version>
+	<version>1.4-M1</version>
   </parent>
  
   <groupId>UTSMetathesaurus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,86 +1,87 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>org.openinfobutton</groupId>
-  <artifactId>oib-parent</artifactId>
-  <version>1.4-SNAPSHOT</version>
-  <packaging>pom</packaging>
-  
-    <scm>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.openinfobutton</groupId>
+	<artifactId>oib-parent</artifactId>
+	<version>1.4-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+	<scm>
 		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
 		<developerConnection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
 		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
-	  <tag>HEAD</tag>
-  </scm>
-  <properties>
-  	<openinfobutton.version>1.4-SNAPSHOT</openinfobutton.version>
-  </properties>
-  
-  <build>
-  	<pluginManagement>
-	  <plugins>
-<plugin>
-  <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-release-plugin</artifactId>
-      <version>2.5</version>
-        <dependencies>
-	    <dependency>
-	          <groupId>org.apache.maven.scm</groupId>
-		        <artifactId>maven-scm-provider-gitexe</artifactId>
-			      <version>1.9</version>
-			          </dependency>
-				    </dependencies>
-				    </plugin>
-	  </plugins>
-  	</pluginManagement>
-  </build>
-  <dependencyManagement>
-  <dependencies>
-   <dependency>
-  <groupId>edu.utah.openinfobutton</groupId>
-  <artifactId>oib-ext-resources</artifactId>
-  <version>${openinfobutton.version}</version>
-   </dependency>
-   <dependency>
-  <groupId>org.openinfobutton</groupId>
-  <artifactId>oib-profile-schema</artifactId>
-  <version>${openinfobutton.version}</version>
-   </dependency>
-   <dependency>
-  <groupId>org.openinfobutton</groupId>
-  <artifactId>oib-profile-schema</artifactId>
-  <version>${openinfobutton.version}</version>
-   </dependency>
-   <dependency>
-  <groupId>org.openinfobutton</groupId>
-  <artifactId>oib-request-db</artifactId>
-  <version>${openinfobutton.version}</version>
-   </dependency>
-   <dependency>
-  <groupId>edu.utah.openinfobutton</groupId>
-  <artifactId>oib-request-inference-rxnorm</artifactId>
-  <version>${openinfobutton.version}</version>
-   </dependency>
-     
-   <dependency>
-  <groupId>org.openinfobutton</groupId>
-  <artifactId>oib-request-schema</artifactId>
-  <version>${openinfobutton.version}</version>
-   </dependency>
-   
-   <dependency>
-  <groupId>org.openinfobutton</groupId>
-  <artifactId>oib-request-service</artifactId>
-  <version>${openinfobutton.version}</version>
-   </dependency>
-   
-   <dependency>
-  <groupId>UTSMetathesaurus</groupId>
-  <artifactId>uts-metathesaurus</artifactId>
-  <version>${openinfobutton.version}</version>
-   </dependency>
-    </dependencies> 
-  </dependencyManagement>
-    <modules>
-        <module>oib-request</module>
-    </modules>
+		<tag>HEAD</tag>
+	</scm>
+	<properties>
+		<openinfobutton.version>1.4-SNAPSHOT</openinfobutton.version>
+	</properties>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-release-plugin</artifactId>
+					<version>2.5</version>
+					<dependencies>
+						<dependency>
+							<groupId>org.apache.maven.scm</groupId>
+							<artifactId>maven-scm-provider-gitexe</artifactId>
+							<version>1.9</version>
+						</dependency>
+					</dependencies>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>edu.utah.openinfobutton</groupId>
+				<artifactId>oib-ext-resources</artifactId>
+				<version>${openinfobutton.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.openinfobutton</groupId>
+				<artifactId>oib-profile-schema</artifactId>
+				<version>${openinfobutton.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.openinfobutton</groupId>
+				<artifactId>oib-profile-schema</artifactId>
+				<version>${openinfobutton.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.openinfobutton</groupId>
+				<artifactId>oib-request-db</artifactId>
+				<version>${openinfobutton.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>edu.utah.openinfobutton</groupId>
+				<artifactId>oib-request-inference-rxnorm</artifactId>
+				<version>${openinfobutton.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.openinfobutton</groupId>
+				<artifactId>oib-request-schema</artifactId>
+				<version>${openinfobutton.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.openinfobutton</groupId>
+				<artifactId>oib-request-service</artifactId>
+				<version>${openinfobutton.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>UTSMetathesaurus</groupId>
+				<artifactId>uts-metathesaurus</artifactId>
+				<version>${openinfobutton.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+	<modules>
+		<module>oib-request</module>
+	</modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,20 +1,19 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <parent>
-  	<groupId>org.openinfobutton</groupId>
-	<artifactId>oib-parent</artifactId>
-	<version>1.4-SNAPSHOT</version>
-  </parent>
-  <artifactId>oib-request</artifactId>
+  <groupId>org.openinfobutton</groupId>
+  <artifactId>oib-parent</artifactId>
+  <version>1.4-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <name>oib-request</name>
   
     <scm>
 		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
 		<developerConnection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
 		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
 	</scm>
+  <properties>
+  	<openinfobutton.version>1.4-SNAPSHOT</openinfobutton.version>
+  </properties>
   
   <build>
   	<pluginManagement>
@@ -29,12 +28,6 @@
   </build>
   
     <modules>
-        <module>oib-profile-schema</module>
-        <module>oib-request-schema</module>
-        <module>oib-request-db</module>
-        <module>oib-request-inference-rxnorm</module>
-        <module>uts-metathesaurus</module>
-        <module>oib-ext-resources</module>
-        <module>oib-request-service</module>
+        <module>oib-request</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,18 +1,18 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.openinfobutton</groupId>
   <artifactId>oib-parent</artifactId>
-  <version>1.4-SNAPSHOT</version>
+  <version>1.4-M1</version>
   <packaging>pom</packaging>
   
     <scm>
 		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
 		<developerConnection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
 		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
-	</scm>
+	  <tag>1.4-M1</tag>
+  </scm>
   <properties>
-  	<openinfobutton.version>1.4-SNAPSHOT</openinfobutton.version>
+  	<openinfobutton.version>1.4-M1</openinfobutton.version>
   </properties>
   
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -17,16 +17,69 @@
   
   <build>
   	<pluginManagement>
-	  	<plugins>
-	      <plugin>
-	        <groupId>org.apache.maven.plugins</groupId>
-	        <artifactId>maven-release-plugin</artifactId>
-	        <version>2.5</version>
-	      </plugin>
-	    </plugins>
+	  <plugins>
+<plugin>
+  <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-release-plugin</artifactId>
+      <version>2.5</version>
+        <dependencies>
+	    <dependency>
+	          <groupId>org.apache.maven.scm</groupId>
+		        <artifactId>maven-scm-provider-gitexe</artifactId>
+			      <version>1.9</version>
+			          </dependency>
+				    </dependencies>
+				    </plugin>
+	  </plugins>
   	</pluginManagement>
   </build>
-  
+  <dependencyManagement>
+  <dependencies>
+   <dependency>
+  <groupId>edu.utah.openinfobutton</groupId>
+  <artifactId>oib-ext-resources</artifactId>
+  <version>${openinfobutton.version}</version>
+   </dependency>
+   <dependency>
+  <groupId>org.openinfobutton</groupId>
+  <artifactId>oib-profile-schema</artifactId>
+  <version>${openinfobutton.version}</version>
+   </dependency>
+   <dependency>
+  <groupId>org.openinfobutton</groupId>
+  <artifactId>oib-profile-schema</artifactId>
+  <version>${openinfobutton.version}</version>
+   </dependency>
+   <dependency>
+  <groupId>org.openinfobutton</groupId>
+  <artifactId>oib-request-db</artifactId>
+  <version>${openinfobutton.version}</version>
+   </dependency>
+   <dependency>
+  <groupId>edu.utah.openinfobutton</groupId>
+  <artifactId>oib-request-inference-rxnorm</artifactId>
+  <version>${openinfobutton.version}</version>
+   </dependency>
+     
+   <dependency>
+  <groupId>org.openinfobutton</groupId>
+  <artifactId>oib-request-schema</artifactId>
+  <version>${openinfobutton.version}</version>
+   </dependency>
+   
+   <dependency>
+  <groupId>org.openinfobutton</groupId>
+  <artifactId>oib-request-service</artifactId>
+  <version>${openinfobutton.version}</version>
+   </dependency>
+   
+   <dependency>
+  <groupId>UTSMetathesaurus</groupId>
+  <artifactId>uts-metathesaurus</artifactId>
+  <version>${openinfobutton.version}</version>
+   </dependency>
+    </dependencies> 
+  </dependencyManagement>
     <modules>
         <module>oib-request</module>
     </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -2,17 +2,17 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.openinfobutton</groupId>
   <artifactId>oib-parent</artifactId>
-  <version>1.4-M1</version>
+  <version>1.4-SNAPSHOT</version>
   <packaging>pom</packaging>
   
     <scm>
 		<connection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</connection>
 		<developerConnection>scm:git:https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</developerConnection>
 		<url>https://tools.regenstrief.org/stash/scm/hl7t/openinfobutton</url>
-	  <tag>1.4-M1</tag>
+	  <tag>HEAD</tag>
   </scm>
   <properties>
-  	<openinfobutton.version>1.4-M1</openinfobutton.version>
+  	<openinfobutton.version>1.4-SNAPSHOT</openinfobutton.version>
   </properties>
   
   <build>


### PR DESCRIPTION
As we rely on stable releases (i.e. non-snapshot artifacts), our fork includes some additional changes.  I figured I would share these with you all in case you want to follow.

Within oib-request, I noticed that versions of the modules did not specify -SNAPSHOT (i.e. 1.4 instead of 1.4-SNAPSHOT).  By convention, when installed/deployed, these artifacts are mis-represented.  So, I added the –SNAPSHOT to the managed modules within oib-request.  I also changed the dependency on edu.utah.further.core from snapshot to 1.4.0 release.
Now, there are no transitive snapshot dependencies and I can use the Maven release plugin to create a release.

For example:
$ mvn clean release:clean release:prepare release:perform -DuseReleaseProfile=false -Dgoals=deploy -DautoVersionSubmodules=true -Darguments='-DskipTests -DaltDeploymentRepository=internal::default::http://arm.regenstrief.org/archiva/repository/internal'

• In the README.md, you mention removing “Duke” references, yet some groupIds still reflect “Utah” edu.utah.openinfobutton.  Maybe this is appropriate.  If this was an oversight and you intend for all artifacts to be “org.openinfobutton”-related (i.e. all have that as the groupId), I might suggest having all oib-request modules add a <parent> section, like below.  This would allow you to omit groupId & version from all submodules, inheriting “org.openinfobutton” and version 1.4-SNAPSHOT.  This would assume that you intend to version all modules consistently.  There are a few advantages with this approach.  You can see with my changes, I have added a root pom.xml to the repository root (to get around a Maven release plugin scm bug when releasing from non-repository-root directories like oib-request/pom.xml), with only a single module (oib-request).  This root/aggregator pom.xml is where the dependencyManagement is done for each module.  I opted for minimal changes in order to release so I just listed the modules but you could add all dependencies in this section and remove specific versions from each descendent pom.xml.   Each pom.xml has a parent declaration and inherits from the parent.
Let me know if you have any questions.
   <parent>
    <groupId>org.openinfobutton</groupId>
    <artifactId>oib-request</artifactId>
    <version>1.4-SNAPSHOT</version>
  </parent>

Other Items for Consideration (Not Included in Pull Request):
• I noticed that during compilation, URLs to WSDLs are used.  I have run into cases where the compilation fails due to remote web service availability.  I might suggest storing a copy of the WSDL in src/main/resources so that the service availability is not a requirement for compilation/testing.
• Revert “outputDirectory” of maven jaxb plugin to something like the default (Default value is: ${project.build.directory}/generated-sources/jaxb).  Having the classes generated in the build directory (target) would prevent you from having to keep under DCVS and therefore the generated classes from showing under “git status”.
